### PR TITLE
Add custom color overrides for SPL theme

### DIFF
--- a/web/themes/custom/spl/css/custom.css
+++ b/web/themes/custom/spl/css/custom.css
@@ -1,0 +1,11 @@
+:root,
+[data-bs-theme="light"] {
+  --bs-primary: #B3CB4F;
+  --bs-primary-rgb: 179, 203, 79;
+  --bs-secondary: #846F3E;
+  --bs-secondary-rgb: 132, 111, 62;
+  --bs-tertiary: #484132;
+  --bs-tertiary-rgb: 72, 65, 50;
+  --bs-link-color: var(--bs-primary);
+  --bs-link-hover-color: #99af49;
+}

--- a/web/themes/custom/spl/spl.libraries.yml
+++ b/web/themes/custom/spl/spl.libraries.yml
@@ -2,3 +2,4 @@ global-styling:
   css:
     theme:
       css/style.css: {}
+      css/custom.css: {}


### PR DESCRIPTION
## Summary
- override Bootstrap color variables with custom palette
- load custom color overrides via library

## Testing
- `npm install -g sass`


------
https://chatgpt.com/codex/tasks/task_e_6859c032c4888323893f7377a11cf408